### PR TITLE
fix: avert install fail by upgrading dependencies ipfs and pubsub-room

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "browserify": "^14.4.0",
     "http-server": "^0.10.0",
-    "ipfs": "^0.27.3",
-    "ipfs-pubsub-room": "^1.1.3"
+    "ipfs": "^0.31.7",
+    "ipfs-pubsub-room": "^1.2.1"
   }
 }


### PR DESCRIPTION
Fixes #11 by upgrading dependencies `ipfs` and `ipfs-pubsub-room`.

One issue that is created by this is that when the server is running and you access the frontend, errors are printed to console whenever a message is recieved, as per below:
```
Uncaught Error: no protocol with name: p2p-webrtc-star
    at Protocols (app.js:88879)
    at stringToStringTuples (app.js:88111)
    at stringToBuffer (app.js:88236)
    at Object.fromString (app.js:88244)
    at new Multiaddr (app.js:88438)
    at Multiaddr (app.js:88426)
    at WebRTCStar._peerDiscovered (app.js:59675)
    at Socket.Emitter.emit (app.js:17023)
    at Socket.onevent (app.js:111545)
    at Socket.onpacket (app.js:111503)
```
